### PR TITLE
chore(web): registrar packageManager do pnpm no package.json

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,5 +24,6 @@
     "@types/react-dom": "^18.3.0",
     "typescript": "^5.5.4",
     "vite": "^5.4.2"
-  }
+  },
+  "packageManager": "pnpm@9.0.0+sha512.b4106707c7225b1748b61595953ccbebff97b54ad05d002aa3635f633b9c53cd666f7ce9b8bc44704f1fa048b9a49b55371ab2d9e9d667d1efe2ef1514bcd513"
 }


### PR DESCRIPTION
Registra o campo packageManager para evitar diffs do Corepack/PNPM em build.