### PR TITLE
chore(docker): otimiza build context com .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,52 @@
+# Global ignore for monorepo root
+# Keep build contexts lean when building from the repository root
+
+# Dependencies and package manager caches
+node_modules
+.pnpm
+.pnpm-store
+
+# Build outputs and coverage
+Dist
+DIST
+dist
+build
+coverage
+
+# Caches
+.cache
+.eslintcache
+
+# Editor/OS files
+.vscode
+.idea
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Environment files (keep example)
+.env
+.env.*
+!.env.example
+
+# VCS
+.git
+.gitattributes
+.gitignore
+
+# Framework-specific caches (safe to ignore even if unused)
+.next
+.nuxt
+.turbo
+.svelte-kit
+.storybook
+
+# Temporary files
+.tmp
+tmp
+temp

--- a/apps/api/.dockerignore
+++ b/apps/api/.dockerignore
@@ -1,0 +1,48 @@
+# Exclude heavy or local-only artifacts from Docker build context
+
+# Dependencies and package manager caches
+node_modules
+.pnpm
+.pnpm-store
+
+# Build outputs and coverage
+Dist
+DIST
+dist
+build
+coverage
+
+# Test/coverage/caches
+.cache
+.eslintcache
+
+# Editors/OS
+.vscode
+.idea
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Env files and VCS
+.env
+.env.*
+!.env.example
+.git
+.gitattributes
+.gitignore
+
+# Framework caches (even if unused)
+.next
+.nuxt
+.turbo
+.svelte-kit
+
+# Temp files
+.tmp
+tmp
+temp

--- a/apps/web/.dockerignore
+++ b/apps/web/.dockerignore
@@ -1,0 +1,53 @@
+# Exclude heavy or local-only artifacts from Docker build context
+
+# Dependencies and package manager caches
+node_modules
+.pnpm
+.pnpm-store
+
+# Build outputs
+Dist
+DIST
+dist
+build
+coverage
+
+# Test/coverage/caches
+.cache
+.eslintcache
+
+# Editors/OS
+.vscode
+.idea
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Env files and VCS
+.env
+.env.*
+!.env.example
+.git
+.gitattributes
+.gitignore
+
+# E2E/Storybook/Reports
+.storybook
+cypress
+playwright-report
+
+# Framework caches (even if unused)
+.next
+.nuxt
+.turbo
+.svelte-kit
+
+# Temp files
+.tmp
+tmp
+temp


### PR DESCRIPTION
Adiciona .dockerignore na raiz, apps/web e apps/api para reduzir o contexto de build do Docker e acelerar builds (especialmente no WSL). Sem mudanças de runtime.