### PR TITLE
fix(api): append .js extensions to local ESM imports

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -9,8 +9,8 @@ const __dirname = path.dirname(__filename);
 // Load env from project root .env (../../.env)
 dotenv({ path: path.resolve(__dirname, '../../..', '.env') });
 
-import { env } from './lib/env';
-import { buildApp } from './server/app';
+import { env } from './lib/env.js';
+import { buildApp } from './server/app.js';
 
 const app = buildApp();
 // Railway define a variável PORT automaticamente; use-a quando disponível

--- a/apps/api/src/server/app.ts
+++ b/apps/api/src/server/app.ts
@@ -2,18 +2,18 @@ import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import swaggerUi from 'swagger-ui-express';
-import { swaggerSpec } from './swagger';
-import { healthRouter } from './routes/health';
-import { authRouter } from './routes/auth';
-import { meRouter } from './routes/me';
-import { convertRouter } from './routes/convert';
-import { historyRouter } from './routes/history';
+import { swaggerSpec } from './swagger.js';
+import { healthRouter } from './routes/health.js';
+import { authRouter } from './routes/auth.js';
+import { meRouter } from './routes/me.js';
+import { convertRouter } from './routes/convert.js';
+import { historyRouter } from './routes/history.js';
 import { favoritesRouter } from './routes/favorites.js';
 import { cryptosRouter } from './routes/cryptos.js';
-import { env } from '../lib/env';
-import { httpLogger } from './middleware/logger';
-import { generalLimiter, authLimiter } from './middleware/rateLimit';
-import { errorHandler } from './middleware/error';
+import { env } from '../lib/env.js';
+import { httpLogger } from './middleware/logger.js';
+import { generalLimiter, authLimiter } from './middleware/rateLimit.js';
+import { errorHandler } from './middleware/error.js';
 
 export function buildApp() {
   const app = express();

--- a/apps/api/src/server/middleware/auth.ts
+++ b/apps/api/src/server/middleware/auth.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
-import { env } from '../../lib/env';
+import { env } from '../../lib/env.js';
 
 export function auth(req: Request, res: Response, next: NextFunction) {
   try {

--- a/apps/api/src/server/middleware/logger.ts
+++ b/apps/api/src/server/middleware/logger.ts
@@ -1,7 +1,7 @@
 import pino from 'pino';
 import { pinoHttp } from 'pino-http';
 import crypto from 'crypto';
-import { env } from '../../lib/env';
+import { env } from '../../lib/env.js';
 import type { IncomingMessage, ServerResponse } from 'http';
 
 export const logger = pino({ level: env.LOG_LEVEL });

--- a/apps/api/src/server/middleware/validate.ts
+++ b/apps/api/src/server/middleware/validate.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import type { ZodSchema } from 'zod';
-import { HttpError } from './error';
+import { HttpError } from './error.js';
 
 export function validate({ body, query, params }: { body?: ZodSchema<any>; query?: ZodSchema<any>; params?: ZodSchema<any>; }) {
   return (req: Request, _res: Response, next: NextFunction) => {

--- a/apps/api/src/server/routes/auth.ts
+++ b/apps/api/src/server/routes/auth.ts
@@ -2,9 +2,9 @@ import { Router, type Request, type Response, type NextFunction } from 'express'
 import { z } from 'zod';
 import bcrypt from 'bcryptjs';
 import jwt, { type SignOptions, type Secret } from 'jsonwebtoken';
-import { prisma } from '../../lib/prisma';
-import { env } from '../../lib/env';
-import { validate } from '../middleware/validate';
+import { prisma } from '../../lib/prisma.js';
+import { env } from '../../lib/env.js';
+import { validate } from '../middleware/validate.js';
 
 const router = Router();
 

--- a/apps/api/src/server/routes/convert.ts
+++ b/apps/api/src/server/routes/convert.ts
@@ -1,8 +1,8 @@
 import { Router, type Request, type Response, type NextFunction } from 'express';
-import { auth } from '../middleware/auth';
-import { prisma } from '../../lib/prisma';
+import { auth } from '../middleware/auth.js';
+import { prisma } from '../../lib/prisma.js';
 import { z } from 'zod';
-import { validate } from '../middleware/validate';
+import { validate } from '../middleware/validate.js';
 
 export const convertRouter = Router();
 

--- a/apps/api/src/server/routes/cryptos.ts
+++ b/apps/api/src/server/routes/cryptos.ts
@@ -1,8 +1,8 @@
 import { Router, type Request, type Response, type NextFunction } from 'express';
-import { prisma } from '../../lib/prisma';
-import { auth } from '../middleware/auth';
+import { prisma } from '../../lib/prisma.js';
+import { auth } from '../middleware/auth.js';
 import { z } from 'zod';
-import { validate } from '../middleware/validate';
+import { validate } from '../middleware/validate.js';
 
 export const cryptosRouter = Router();
 

--- a/apps/api/src/server/routes/favorites.ts
+++ b/apps/api/src/server/routes/favorites.ts
@@ -1,8 +1,8 @@
 import { Router, type Request, type Response, type NextFunction } from 'express';
-import { auth } from '../middleware/auth';
-import { prisma } from '../../lib/prisma';
+import { auth } from '../middleware/auth.js';
+import { prisma } from '../../lib/prisma.js';
 import { z } from 'zod';
-import { validate } from '../middleware/validate';
+import { validate } from '../middleware/validate.js';
 
 export const favoritesRouter = Router();
 

--- a/apps/api/src/server/routes/history.ts
+++ b/apps/api/src/server/routes/history.ts
@@ -1,8 +1,8 @@
 import { Router, type Request, type Response, type NextFunction } from 'express';
-import { auth } from '../middleware/auth';
-import { prisma } from '../../lib/prisma';
+import { auth } from '../middleware/auth.js';
+import { prisma } from '../../lib/prisma.js';
 import { z } from 'zod';
-import { validate } from '../middleware/validate';
+import { validate } from '../middleware/validate.js';
 
 export const historyRouter = Router();
 

--- a/apps/api/src/server/routes/me.ts
+++ b/apps/api/src/server/routes/me.ts
@@ -1,6 +1,6 @@
 import { Router, type Request, type Response, type NextFunction } from 'express';
-import { auth } from '../middleware/auth';
-import { prisma } from '../../lib/prisma';
+import { auth } from '../middleware/auth.js';
+import { prisma } from '../../lib/prisma.js';
 
 export const meRouter = Router();
 


### PR DESCRIPTION
Node ESM exige extensão em imports relativos no runtime. Atualizados imports em:
- apps/api/src/index.ts
- apps/api/src/server/app.ts
- apps/api/src/server/middleware/{auth,logger,validate}.ts
- apps/api/src/server/routes/{auth,convert,cryptos,favorites,history,me}.ts Sem mudanças de lógica. Dockerfile e scripts de produção permanecem os mesmos.

## Descrição

Descreva as mudanças realizadas e o contexto.

## Tipo de Alteração
- [ ] 🐛 Correção de bug
- [ ] ✨ Nova funcionalidade
- [ ] ♻️ Refatoração de código
- [ ] 📝 Documentação
- [ ] 🔧 Configuração / CI-CD

## Issue Relacionada
Closes #

## Como Testar?
1. Execute a rota `[MÉTODO] /endpoint` com o seguinte corpo: `{...}`
2. Verifique se a resposta é `200 OK` e o corpo da resposta é `{...}`

## Checklist
- [ ] Meu código segue os padrões de estilo deste projeto.
- [ ] Realizei uma auto-revisão do meu próprio código.
- [ ] Adicionei/atualizei a documentação relevante (se necessário).
